### PR TITLE
Fix bug khi chấm bằng python checker

### DIFF
--- a/inc/definitions.h
+++ b/inc/definitions.h
@@ -32,6 +32,7 @@
 const int EXIT_TIMEOUT = 124;
 const int EXIT_AC      = 42;
 const int EXIT_WA      = 43;
+const int PCLOSE_ERROR = 127;
 
 typedef long double flt;
 

--- a/src/Checker.cpp
+++ b/src/Checker.cpp
@@ -7,7 +7,14 @@ extern configer::configer bconf;
 Checker::Checker() {}
 
 Checker::Checker(const std::string& filename, double timeout, const std::string& options): Solution(filename, timeout) {
-    run_command = JUDGE_BIN "/\"" + raw + "\"" + " \"%s\" \"%s\" \"%s\" " + options + " < \"%s\"";
+    if (ext == "cpp" || ext == "cc") {
+        run_command = JUDGE_BIN "\"" + raw + "\"";
+    } else if (ext == "py") {
+        run_command = "pypy3 \"" + filename + "\"";
+    } else {
+        throw std::runtime_error("Not supported checker extension: " + ext + "\n");
+    }
+    run_command += " \"%s\" \"%s\" \"%s\" " + options + " < \"%s\"";
 }
 
 CompileResult Checker::compile() const {

--- a/src/Checker.cpp
+++ b/src/Checker.cpp
@@ -10,7 +10,13 @@ Checker::Checker(const std::string& filename, double timeout, const std::string&
     if (ext == "cpp" || ext == "cc") {
         run_command = JUDGE_BIN "\"" + raw + "\"";
     } else if (ext == "py") {
-        run_command = "pypy3 \"" + filename + "\"";
+        run_command = "pypy3 --version";
+        int exit_code = pclose(popen(run_command.data(), "r")) >> 8;
+        if (exit_code == PCLOSE_ERROR) {
+            run_command = "python3 \"" + filename + "\"";
+        } else {
+            run_command = "pypy3 \"" + filename + "\"";
+        }
     } else {
         throw std::runtime_error("Not supported checker extension: " + ext + "\n");
     }


### PR DESCRIPTION
# Description
Không tìm thấy file run checker khi chạy bằng python checker.
# How to Reproduce

File `sol.py`
```python
print("Hello")
```

File `checker.py`
```python
EXIT_AC = 42
EXIT_WA = 43

if __name__ == "__main__":
    exit(EXIT_AC)
```

Tạo file test rỗng `TestData/01.in`, `TestData/01.ans`

Chấm bằng python checker:
```sh
./judge sol.py -C checker.py
```

**Screenshot**

![](https://github.com/nxphuc/bigo_judger/assets/29222623/23d0a805-caa5-426a-b4a7-0efa15ddb907)

# Bug Fixed
![](https://github.com/nxphuc/bigo_judger/assets/29222623/c71768f1-6b8b-4dd9-8519-1f522d3b853c)

